### PR TITLE
feat: nginx serves jupyterhub with https

### DIFF
--- a/Hetzner server/sites-available/hub.brightway.dev
+++ b/Hetzner server/sites-available/hub.brightway.dev
@@ -3,8 +3,6 @@ server {
     server_name hub.brightway.dev;
     access_log  /var/log/nginx/hub.brightway.dev.access.log;
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
 
     location / {
         proxy_pass http://localhost:8100;


### PR DESCRIPTION
+ basic "sites-avail" file does not include https, we let certbot add this details
+ ubuntu 20 has an automated certbot based certification renewal, so no special thing to do
+ the certificate was generated using the nginx authenticator (and not the dns one that needs a TXT record)